### PR TITLE
Feature/net kernel.start 2 longnames

### DIFF
--- a/lib/cloister/application.ex
+++ b/lib/cloister/application.ex
@@ -10,8 +10,10 @@ defmodule Cloister.Application do
 
   @impl Application
   def start(_type, _args) do
+    manager = Application.get_env(:cloister, :manager, [])
+
     children = [
-      Cloister.Manager
+      {Cloister.Manager, [manager]}
     ]
 
     opts = [strategy: :one_for_one, name: Cloister.Supervisor]

--- a/lib/cloister/manager.ex
+++ b/lib/cloister/manager.ex
@@ -14,8 +14,10 @@ defmodule Cloister.Manager do
   def init(state) do
     state =
       state
+      |> Keyword.put_new(:otp_app, Application.get_env(:cloister, :otp_app, :cloister))
       |> Keyword.put_new(:listener, Cloister.Modules.listener_module())
-      |> Keyword.put_new(:otp_app, :cloister)
+
+    {monitor_opts, state} = Keyword.pop(state, :monitor_opts, [])
 
     {additional_modules, state} =
       Keyword.pop(
@@ -28,7 +30,7 @@ defmodule Cloister.Manager do
 
     children =
       [
-        {Cloister.Monitor, [state: state]},
+        {Cloister.Monitor, [{:state, state} | monitor_opts]},
         Cloister,
         Cloister.Node
       ] ++ additional_modules

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Cloister.MixProject do
   use Mix.Project
 
   @app :cloister
-  @version "0.3.3"
+  @version "0.3.4"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -98,7 +98,7 @@ defmodule Cloister.MixProject do
       logo: "stuff/cloister-48x48.png",
       source_url: "https://github.com/am-kantox/#{@app}",
       assets: "stuff/images",
-      extras: ["README.md"],
+      extras: ["README.md", "stuff/configuration.md"],
       groups_for_modules: []
     ]
   end

--- a/stuff/configuration.md
+++ b/stuff/configuration.md
@@ -1,0 +1,45 @@
+# Cloister Configuration
+
+_Cloister_ is another cluster support library that aims to be a drop-in for cluster support in distributed environment.
+
+It relies mainly on configuration because it’s started as a separate application _before_ the main _OTP_ application that uses it and relies on startup phases to block until the consensus is reached. For the very fine tuning, one might put `:cloister` into `:included_applications` _and_ embed `Cloister.Manager` manually into the supervision tree. See `Cloister.Application.start_phase/3` for the inspiration on how to wait till consensus is reached.
+
+On a bird view, the config might look like:
+
+```elixir
+config :cloister,
+  # OTP application this cloister runs for
+  otp_app: :my_app,                    # default: :cloister
+
+  # the way the cloister knows how to build cluster
+  sentry: :"cloister.local",           # service name
+  # or node list (default `[node()]`)
+  # sentry: ~w[c1@127.0.0.1 c2@127.0.0.1]a
+
+  # number of nodes to consider consensus
+  consensus: 3,                        # default
+
+  # listener to be called when the ring is changed
+  listener: MyApp.Listener,            # default: Stub
+
+  # monitor to handle ring changes
+  monitor: MyApp.Monitor,              # default: Stub
+
+  # additional modules to include into `Manager`’s supervision tree
+  additional_modules: [Cloister.Void], # useful for tests / dev
+
+  # the name of the `HashRing` to be used
+  # if set, the _HashRing_ is assumed to be managed externally
+  ring: :cloister,                     # default
+
+  # manager configuration, used when cloister app is not started
+  manager: [
+    name: Cloister.Manager,            # default
+    state: [
+      otp_app: :my_app,                # default: :cloister
+      listener: MyApp.Listener,        # default: Stub
+      monitor_opts: [],                # options for monitor
+      additional_modules: []           # additional modules as above
+    ]
+  ]
+```

--- a/stuff/sources.md
+++ b/stuff/sources.md
@@ -1,5 +1,5 @@
 # Sources and Links
 
 - https://github.com/killme2008/corfu abandoned implementation of [Paxos](https://en.wikipedia.org/wiki/Paxos_(computer_science)) in Elixir, 3yo;
-- https://github.com/timgestson/expaxos another Paxos implementation, 6yo
--
+- https://github.com/timgestson/expaxos another _Paxos_ implementation, 6yo
+- https://github.com/slogsdon/elixir-raft a [`Raft`](https://raft.github.io/) consensus algorithm implementation in _Elixir_


### PR DESCRIPTION
When invoked with no node name specified, but with a service provided, attempts to restart `:net_kernel` with `:longnames` where the name is guessed from `:otp_app` and IP.